### PR TITLE
Introduce chromatic scale definitions at psynth::music

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,6 +164,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "derivative"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "dirs"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -298,6 +308,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_enum"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "derivative 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_enum_derive 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro-crate 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -332,6 +362,14 @@ version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "proc-macro-crate"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "toml 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -347,6 +385,7 @@ dependencies = [
  "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "cpal 0.11.0 (git+https://github.com/RustAudio/cpal)",
  "hound 3.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_enum 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "ringbuf 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustyline 6.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zmq 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -453,6 +492,11 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "serde"
+version = "1.0.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "shlex"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -502,6 +546,14 @@ dependencies = [
 name = "toml"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "toml"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "unicode-segmentation"
@@ -599,6 +651,7 @@ dependencies = [
 "checksum coreaudio-sys 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "e81f1c165c33ffab90a03077ac3b03462b34d5947145dfa48102e063d581502c"
 "checksum cpal 0.11.0 (git+https://github.com/RustAudio/cpal)" = "<none>"
 "checksum crossbeam-utils 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
+"checksum derivative 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1eae4d76b7cefedd1b4f8cc24378b2fbd1ac1b66e3bbebe8e2192d3be81cb355"
 "checksum dirs 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "13aea89a5c93364a98e9b37b2fa237effbb694d5cfe01c5b70941f7eb087d5e3"
 "checksum dirs-sys 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "afa0b23de8fd801745c471deffa6e12d248f962c9fd4b4c33787b055599bde7b"
 "checksum error-chain 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d9435d864e017c3c6afeac1654189b06cdb491cf2ff73dbf0d73b0f292f42ff8"
@@ -617,10 +670,13 @@ dependencies = [
 "checksum nix 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6c722bee1037d430d0f8e687bbdbf222f27cc6e4e68d5caf630857bb2b6dbdce"
 "checksum nom 5.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b471253da97532da4b61552249c521e01e736071f71c1a4f7ebbfbf0a06aad6"
 "checksum num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "c62be47e61d1842b9170f0fdeec8eba98e60e90e5446449a0545e5152acd7096"
+"checksum num_enum 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ca565a7df06f3d4b485494f25ba05da1435950f4dc263440eda7a6fa9b8e36e4"
+"checksum num_enum_derive 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ffa5a33ddddfee04c0283a7653987d634e880347e96b5b2ed64de07efb59db9d"
 "checksum parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252"
 "checksum parking_lot_core 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b876b1b9e7ac6e1a74a6da34d25c42e17e8862aa409cbbbdcfc8d86c6f3bc62b"
 "checksum peeking_take_while 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 "checksum pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)" = "05da548ad6865900e60eaba7f589cc0783590a92e940c26953ff81ddbab2d677"
+"checksum proc-macro-crate 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "e10d4b51f154c8a7fb96fd6dad097cb74b863943ec010ac94b9fd1be8861fe1e"
 "checksum proc-macro2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)" = "6c09721c6781493a2a492a96b5a5bf19b65917fe6728884e7c44dd0c60ca3435"
 "checksum quote 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2bdc6c187c65bca4260c9011c9e3132efe4909da44726bad24cf7572ae338d7f"
 "checksum redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)" = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
@@ -635,6 +691,7 @@ dependencies = [
 "checksum scopeguard 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
+"checksum serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)" = "36df6ac6412072f67cf767ebbde4133a5b2e88e76dc6187fa7104cd16f783399"
 "checksum shlex 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
 "checksum smallvec 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "f7b0758c52e15a8b5e3691eae6cc559f08eee9406e548a4477ba4e67770a82b6"
 "checksum stdweb 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ef5430c8e36b713e13b48a9f709cc21e046723fe44ce34587b73a830203b533e"
@@ -642,6 +699,7 @@ dependencies = [
 "checksum thiserror 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)" = "e3711fd1c4e75b3eff12ba5c40dba762b6b65c5476e8174c1a664772060c49bf"
 "checksum thiserror-impl 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)" = "ae2b85ba4c9aa32dd3343bd80eb8d22e9b54b7688c17ea3907f236885353b233"
 "checksum toml 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "736b60249cb25337bc196faa43ee12c705e426f3d55c214d73a4e7be06f92cb4"
+"checksum toml 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ffc92d160b1eef40665be3a05630d003936a3bc7da7421277846c2613e92c71a"
 "checksum unicode-segmentation 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0"
 "checksum unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ byteorder = "1.3.4"
 # changes that live unreleased on master
 cpal = { git = "https://github.com/RustAudio/cpal" }
 hound = "3.4.0"
+num_enum = "0.4.3"
 ringbuf = "0.2.1"
 rustyline = "6.0.0"
 zmq = "0.9.2"

--- a/README.md
+++ b/README.md
@@ -15,10 +15,18 @@ TODOs:
     - [ ] Define different rooms or parameterize `filters::reverb`
     - [ ] Envelope filters?
     - [ ] Band-pass filters?
+- [ ] Research and implement a few instruments
+    - [ ] At the very least, a good-sounding digital keyboard and some sort of drumkit
+    - [ ] Explore possibility of integration of 3rd-party effects (e.g. VST instruments)
+- [ ] Implement music handling
+    - [x] Notes and operations on notes
+    - [ ] Scales and operations on scales
+    - [ ] Feeding notes/scales into controls
 - [ ] Research and implement more controls
+    - [ ] Consider what a `Keyboard` might be -- how are the buttons mapped to notes, or to sounds?
+      How is the sound from a keypress fed into a `Consumer`?
 - [x] Implement metronome
-- [ ] Explore possibility of integration of 3rd-party effects (e.g. VST instruments)
-- ~~[ ] Sort out the `'static` situation (shouldn't be a requirement for `Generator`, `Filter` types)~~
+- [ ] ~~Sort out the `'static` situation (shouldn't be a requirement for `Generator`, `Filter` types)~~
     - Currently prioritizing ease of use and functionality over correctness -- `'static` as a
       requirement for `Generator` has not proven to be a roadblock in any way, and it may be
       preferable to code littered with `<'a>` explicit lifetimes

--- a/README.md
+++ b/README.md
@@ -30,3 +30,5 @@ TODOs:
     - Currently prioritizing ease of use and functionality over correctness -- `'static` as a
       requirement for `Generator` has not proven to be a roadblock in any way, and it may be
       preferable to code littered with `<'a>` explicit lifetimes
+- [ ] Implement some form of CLI for `psynth-play` such that doing new things doesn't always
+  involve modifying the `bin/main.rs` and recompiling

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1,6 +1,7 @@
 use anyhow::{anyhow, Result};
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
 
+#[allow(unused_imports)]
 use psynth::{
     generators,
     filters,
@@ -10,8 +11,8 @@ use psynth::{
     Consumer,
     FilterComposable,
     Sample,
+    music::notes,
 };
-use psynth::music::notes;
 
 
 fn main() -> Result<()> {
@@ -84,9 +85,17 @@ fn main() -> Result<()> {
     */
     let mut consumer = consumers::MonoConsumer::new(channels)
         .bind(psynth::keys::SimpleKey::new(
-            generators::sine(rate, 440.0),
+            generators::sine(rate, notes::Hz::from(notes::Tone::try_from("F#3")?)),
             controls::StdinPot::new("bool", false, |l| Ok(l.parse::<bool>()?)),
-            1.0, 0.0).into_generator())
+            move |i| {
+                let i_frac = (i as f32) / (rate as f32);
+                if i_frac >= 1.0 { 1.0 } else { i_frac * i_frac }
+            },
+            move |i| {
+                let i_frac = (i as f32) / (rate as f32);
+                if i_frac >= 1.0 { 0.0 } else { (1.0 - i_frac) * (1.0 - i_frac) }
+            },
+            ).into_generator())
         ;
 
     /*

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -11,6 +11,7 @@ use psynth::{
     FilterComposable,
     Sample,
 };
+use psynth::music::notes;
 
 
 fn main() -> Result<()> {
@@ -26,6 +27,7 @@ fn main() -> Result<()> {
     let channels = config.channels as usize;
     let rate: u32 = config.sample_rate.0;
 
+    /*
     // not source controlled, ripped from freesound.org (awesome website!)
     let kick = "../wavs/371192__karolist__acoustic-kick.wav";
     let hum = "../wavs/17231__meatball4u__hum2.wav";
@@ -43,6 +45,11 @@ fn main() -> Result<()> {
             generators::repeat(sampling::VecTrack::try_from_wav_file(rate, hum)?)
                 .compose(filters::gain(0.25)),
             ]));
+    */
+
+    let mut consumer = consumers::MonoConsumer::new(channels)
+        .bind(generators::sine(rate, controls::StdinPot::new("tone", notes::Tone::FIXED_HZ,
+            |line| Ok(notes::Hz::from(notes::Tone::try_from(line)?)))));
 
     let output_stream = output_device.build_output_stream(
         &config,

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -28,61 +28,8 @@ fn main() -> Result<()> {
     let channels = config.channels as usize;
     let rate: u32 = config.sample_rate.0;
 
-    /*
-    // not source controlled, ripped from freesound.org (awesome website!)
-    let kick = "../wavs/371192__karolist__acoustic-kick.wav";
-    let hum = "../wavs/17231__meatball4u__hum2.wav";
-    let mut consumer = consumers::MonoConsumer::new(channels)
-        .bind(controls::join(vec![
-            generators::metronome(rate, 120.0, sampling::VecTrack::try_from_wav_file(rate, kick)?)
-                .fork(|l, r| controls::join2(
-                    controls::GeneratorPot::new(generators::square(rate, 1.0 / 4.0)),
-                    l.compose(filters::comb(rate, 0.25, 0.25, filters::CombDirection::FeedBack)),
-                    r)),
-            generators::sine(rate, controls::StdinPot::default())
-                .compose(filters::gain(0.1))
-                .compose(filters::reverb(rate, 0.0, 0.0))
-                .compose(filters::gain(controls::sine_pot(rate, 1.0 / 3.0, 0.0, 1.0))),
-            generators::repeat(sampling::VecTrack::try_from_wav_file(rate, hum)?)
-                .compose(filters::gain(0.25)),
-            ]));
-    */
-    /*
-    let f: Sample = 220.0;
-    let mut consumer = consumers::MonoConsumer::new(channels)
-        .bind(
-            controls::join2(controls::StdinPot::default(),
-                // even harmonics
-                controls::join(vec![
-                    generators::sine(rate, f)
-                        .compose(filters::ramp_up(rate, 0.05))
-                        .compose(filters::gain(0.5)),
-                    generators::sine(rate, f * 2.0)
-                        .compose(filters::ramp_up(rate, 0.05))
-                        .compose(filters::gain(0.05)),
-                    generators::sine(rate, f * 4.0)
-                        .compose(filters::ramp_up(rate, 0.05))
-                        .compose(filters::gain(0.005)),
-                ]),
-                // odd harmonics
-                controls::join(vec![
-                    generators::sine(rate, f)
-                        .compose(filters::ramp_up(rate, 0.05))
-                        .compose(filters::gain(0.5)),
-                    generators::sine(rate, f * 1.5)
-                        .compose(filters::ramp_up(rate, 0.05))
-                        .compose(filters::gain(0.05)),
-                    generators::sine(rate, f * 3.0)
-                        .compose(filters::ramp_up(rate, 0.05))
-                        .compose(filters::gain(0.005)),
-                ]),
-            )
-            // .compose(filters::gain(controls::StdinPot::default()))
-            .compose(filters::gain(0.5))
-            // .compose(filters::reverb(rate, 0.0, 0.0))
-            // .compose(filters::gain(0.25))
-            );
-    */
+    // demonstrate a key reading `true`/`false` values from stdin, with hardcoded attack and
+    // sustain functions that ramp by t^2
     let mut consumer = consumers::MonoConsumer::new(channels)
         .bind(psynth::keys::SimpleKey::new(
             generators::sine(rate, notes::Hz::from(notes::Tone::try_from("F#3")?)),
@@ -97,12 +44,6 @@ fn main() -> Result<()> {
             },
             ).into_generator())
         ;
-
-    /*
-    let mut consumer = consumers::MonoConsumer::new(channels)
-        .bind(generators::sine(rate, controls::StdinPot::new("tone", notes::Tone::FIXED_HZ,
-            |line| Ok(notes::Hz::from(notes::Tone::try_from(line)?)))));
-    */
 
     let output_stream = output_device.build_output_stream(
         &config,

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -46,10 +46,54 @@ fn main() -> Result<()> {
                 .compose(filters::gain(0.25)),
             ]));
     */
+    /*
+    let f: Sample = 220.0;
+    let mut consumer = consumers::MonoConsumer::new(channels)
+        .bind(
+            controls::join2(controls::StdinPot::default(),
+                // even harmonics
+                controls::join(vec![
+                    generators::sine(rate, f)
+                        .compose(filters::ramp_up(rate, 0.05))
+                        .compose(filters::gain(0.5)),
+                    generators::sine(rate, f * 2.0)
+                        .compose(filters::ramp_up(rate, 0.05))
+                        .compose(filters::gain(0.05)),
+                    generators::sine(rate, f * 4.0)
+                        .compose(filters::ramp_up(rate, 0.05))
+                        .compose(filters::gain(0.005)),
+                ]),
+                // odd harmonics
+                controls::join(vec![
+                    generators::sine(rate, f)
+                        .compose(filters::ramp_up(rate, 0.05))
+                        .compose(filters::gain(0.5)),
+                    generators::sine(rate, f * 1.5)
+                        .compose(filters::ramp_up(rate, 0.05))
+                        .compose(filters::gain(0.05)),
+                    generators::sine(rate, f * 3.0)
+                        .compose(filters::ramp_up(rate, 0.05))
+                        .compose(filters::gain(0.005)),
+                ]),
+            )
+            // .compose(filters::gain(controls::StdinPot::default()))
+            .compose(filters::gain(0.5))
+            // .compose(filters::reverb(rate, 0.0, 0.0))
+            // .compose(filters::gain(0.25))
+            );
+    */
+    let mut consumer = consumers::MonoConsumer::new(channels)
+        .bind(psynth::keys::SimpleKey::new(
+            generators::sine(rate, 440.0),
+            controls::StdinPot::new("bool", false, |l| Ok(l.parse::<bool>()?)),
+            1.0, 0.0).into_generator())
+        ;
 
+    /*
     let mut consumer = consumers::MonoConsumer::new(channels)
         .bind(generators::sine(rate, controls::StdinPot::new("tone", notes::Tone::FIXED_HZ,
             |line| Ok(notes::Hz::from(notes::Tone::try_from(line)?)))));
+    */
 
     let output_stream = output_device.build_output_stream(
         &config,

--- a/src/controls.rs
+++ b/src/controls.rs
@@ -106,8 +106,11 @@ where
     }
 }
 
-impl Pot<f32> for StdinPot<f32> {
-    fn read(&self) -> f32 {
+impl<T> Pot<T> for StdinPot<T>
+where
+    T: Send + Copy + 'static,
+{
+    fn read(&self) -> T {
         match self.receiver.try_recv() {
             Ok(val) => {
                 self.cur.set(val);

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -1,0 +1,89 @@
+use std::cell::{Cell, RefCell};
+
+use crate::{Pot, Generator};
+use crate::sampling::SampleTrack;
+
+
+pub trait Curve<T> {
+    fn read(&self, sample_index: u64) -> T;
+}
+
+
+impl Curve<f32> for f32 {
+    fn read(&self, _: u64) -> f32 {
+        *self
+    }
+}
+
+
+pub struct SimpleKey<T, P, C1, C2>
+where
+    T: SampleTrack + Send,
+    P: Pot<bool> + Send,
+    C1: Curve<f32> + Send,
+    C2: Curve<f32> + Send,
+{
+    track: RefCell<T>,
+    activate: P, // is the key pressed?
+    velocity: C1, // curve describing ramp up after press
+    sustain: C2, // curve describing dropoff after release
+    n_since_activated: Cell<u64>,
+    n_since_deactivated: Cell<u64>,
+}
+
+impl<T, P, C1, C2> SimpleKey<T, P, C1, C2>
+where
+    T: SampleTrack + Send + 'static,
+    P: Pot<bool> + Send + 'static,
+    C1: Curve<f32> + Send + 'static,
+    C2: Curve<f32> + Send + 'static,
+{
+    pub fn new(track: T, activate: P, velocity: C1, sustain: C2) -> Self {
+        Self {
+            track: RefCell::new(track),
+            activate,
+            velocity,
+            sustain,
+            n_since_activated: Cell::new(0),
+            n_since_deactivated: Cell::new(0),
+        }
+    }
+
+    pub fn into_generator(self) -> Generator {
+        Box::new(move || self.read())
+    }
+}
+
+
+impl<T, P, C1, C2> Pot<f32> for SimpleKey<T, P, C1, C2>
+where
+    T: SampleTrack + Send,
+    P: Pot<bool> + Send,
+    C1: Curve<f32> + Send,
+    C2: Curve<f32> + Send,
+{
+    fn read(&self) -> f32 {
+        let is_active = self.activate.read();
+        let n_since_activated_prev = self.n_since_activated.get();
+        let n_since_deactivated_prev = self.n_since_deactivated.get();
+        let mut track_ref = self.track.borrow_mut();
+
+        // just turned on
+        if is_active && n_since_activated_prev == 0 {
+            track_ref.reset();
+            self.n_since_deactivated.set(0);
+        } else if !is_active && n_since_deactivated_prev == 0 {
+            self.n_since_activated.set(0);
+        }
+
+        let next_sample = track_ref.next().unwrap_or(0.0);
+
+        if is_active {
+            self.n_since_activated.set(n_since_activated_prev + 1);
+            next_sample * self.velocity.read(n_since_activated_prev)
+        } else {
+            self.n_since_deactivated.set(n_since_deactivated_prev + 1);
+            next_sample * self.sustain.read(n_since_deactivated_prev)
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub mod consumers;
 pub mod observers;
 pub mod controls;
 pub mod sampling;
+pub mod keys;
 
 
 /// Audio out value at a given instant.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod music;
 pub mod generators;
 pub mod filters;
 pub mod consumers;

--- a/src/music/mod.rs
+++ b/src/music/mod.rs
@@ -1,0 +1,1 @@
+pub mod notes;

--- a/src/music/mod.rs
+++ b/src/music/mod.rs
@@ -1,1 +1,2 @@
 pub mod notes;
+pub mod scales;

--- a/src/music/notes.rs
+++ b/src/music/notes.rs
@@ -1,0 +1,172 @@
+use std::fmt;
+
+
+pub type Hz = f32;
+
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum Note {
+    A,
+    B,
+    C,
+    D,
+    E,
+    F,
+    G,
+}
+
+
+impl fmt::Display for Note {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum Pitch {
+    Flat,
+    Natural,
+    Sharp,
+}
+
+
+impl fmt::Display for Pitch {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", match self {
+            Pitch::Flat => "♭",
+            Pitch::Natural => "",
+            Pitch::Sharp => "♯",
+        })
+    }
+}
+
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum Octave {
+    Zero,
+    One,
+    Two,
+    Three,
+    Four,
+    Five,
+    Six,
+    Seven,
+    Eight,
+}
+
+
+impl fmt::Display for Octave {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", (*self) as i32)
+    }
+}
+
+
+#[derive(Debug, PartialEq)]
+pub struct Tone {
+    pub note: Note,
+    pub pitch: Pitch,
+    pub octave: Octave,
+}
+
+
+impl Tone {
+    const FIXED_HZ: Hz = 440.0;
+    const FIXED_TONE: Self = Tone { note: Note::A, pitch: Pitch::Natural, octave: Octave::Four };
+
+    pub fn new(note: Note, pitch: Pitch, octave: Octave) -> Self {
+        Self { note, pitch, octave }
+    }
+
+    pub fn semitone_rank(&self) -> i32 {
+        use Note::*;
+        use Pitch::*;
+        match self {
+            Tone { note: C, pitch: Natural, .. } => 1,
+            Tone { note: C, pitch: Sharp,   .. } |
+            Tone { note: D, pitch: Flat,    .. } => 2,
+            Tone { note: D, pitch: Natural, .. } => 3,
+            Tone { note: D, pitch: Sharp,   .. } |
+            Tone { note: E, pitch: Flat,    .. } => 4,
+            Tone { note: E, pitch: Natural, .. } => 5,
+            Tone { note: F, pitch: Natural, .. } => 6,
+            Tone { note: F, pitch: Sharp,   .. } |
+            Tone { note: G, pitch: Flat,    .. } => 7,
+            Tone { note: G, pitch: Natural, .. } => 8,
+            Tone { note: G, pitch: Sharp,   .. } |
+            Tone { note: A, pitch: Flat,    .. } => 9,
+            Tone { note: A, pitch: Natural, .. } => 10,
+            Tone { note: A, pitch: Sharp,   .. } |
+            Tone { note: B, pitch: Flat,    .. } => 11,
+            Tone { note: B, pitch: Natural, .. } => 12,
+            t => panic!("does '{}' exist?", t),
+        }
+    }
+
+    pub fn semitone_distance_to(&self, to: &Tone) -> i32 {
+        let inter_octave_dist = (self.octave as i32) - (to.octave as i32);
+        let intra_octave_dist = self.semitone_rank() - to.semitone_rank();
+        intra_octave_dist + (12 * inter_octave_dist)
+    }
+}
+
+
+impl fmt::Display for Tone {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}{}{}", self.note, self.pitch, self.octave)
+    }
+}
+
+
+/// This would have been painful to implement manually!
+///
+/// Formula from [this fantastic MTU resource](https://pages.mtu.edu/~suits/notefreqs.html).
+// TODO: precompute?
+impl From<&Tone> for Hz {
+    fn from(tone: &Tone) -> Self {
+        match tone {
+            t if t == &Tone::FIXED_TONE => Tone::FIXED_HZ,
+            t => {
+                let dist = t.semitone_distance_to(&Tone::FIXED_TONE);
+                Tone::FIXED_HZ * (2.0f32).powf(1.0 / 12.0).powi(dist)
+            },
+        }
+    }
+}
+
+
+impl From<Tone> for Hz {
+    fn from(tone: Tone) -> Self {
+        Hz::from(&tone)
+    }
+}
+
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    static EPSILON: Hz = 0.05; // source numbers were not very precise
+
+    macro_rules! assert_delta {
+        ($left:expr, $right:expr, $delta:expr) => {
+            if ($left - $right).abs() >= $delta {
+                panic!("assertion failed:\nleft:  {}\nright: {}\ndelta: {}", $left, $right, $delta);
+            }
+        };
+    }
+
+    #[test]
+    fn test_tone_conversion() {
+        let c0 = Tone::new(Note::C, Pitch::Sharp, Octave::Zero);
+        assert_delta!(Hz::from(&c0), 17.32, EPSILON);
+        assert_delta!(Hz::from(Tone::new(Note::F, Pitch::Natural, Octave::Six)), 1396.91, EPSILON);
+        assert_delta!(Hz::from(Tone::new(Note::G, Pitch::Flat, Octave::Eight)), 5919.91, EPSILON);
+    }
+
+    #[test]
+    fn test_semitone_distance() {
+        assert_eq!(Tone::FIXED_TONE.semitone_distance_to(&Tone::FIXED_TONE), 0);
+    }
+}

--- a/src/music/notes.rs
+++ b/src/music/notes.rs
@@ -180,6 +180,8 @@ impl fmt::Display for Octave {
 }
 
 
+/// A tone on a chromatic (12-tone) scale, including octave.
+///
 /// Hiding the fields of `Tone` and providing getters like this allows for full external visibility
 /// but blocked direct instantiation, which is very important as many implemented operations will
 /// fail on invalid `Tone`s.
@@ -213,6 +215,7 @@ impl Tone {
         self.2
     }
 
+    /// Attempt to create a `Tone` from a string, e.g. `A#7`.
     // NOTE: can't impl TryFrom for generic type param (like AsRef<str>):
     // https://github.com/rust-lang/rust/issues/50133
     pub fn try_from<S>(s: S) -> Result<Self>
@@ -235,6 +238,9 @@ impl Tone {
         }
     }
 
+    /// Rank the tone within an octave.
+    ///
+    /// Mainly useful for determining relationships between different tones.
     pub fn semitone_rank(&self) -> i32 {
         use Note::*;
         use Pitch::*;
@@ -260,6 +266,10 @@ impl Tone {
         }
     }
 
+    /// Determine how far away this `Tone` is to the provided tone, in terms of semitone-steps.
+    ///
+    /// Returns a positive value if `self` is above `to`, negative if `self` is below `to` (i.e.
+    /// if `self` has a lower frequency than `to`).
     pub fn semitone_distance_to(&self, to: &Tone) -> i32 {
         let inter_octave_dist = (self.octave() as i32) - (to.octave() as i32);
         let intra_octave_dist = self.semitone_rank() - to.semitone_rank();
@@ -393,6 +403,7 @@ mod test {
     #[test]
     fn test_semitone_distance() {
         assert_eq!(Tone::FIXED_TONE.semitone_distance_to(&Tone::FIXED_TONE), 0);
+        assert_eq!(Tone::new(C, Sharp, Zero).unwrap().semitone_distance_to(&Tone::FIXED_TONE), -56);
     }
 
     #[test]

--- a/src/music/notes.rs
+++ b/src/music/notes.rs
@@ -52,14 +52,15 @@ impl Note {
 impl TryFrom<char> for Note {
     type Error = anyhow::Error;
     fn try_from(c: char) -> Result<Self, Self::Error> {
+        use Note::*;
         match c {
-            'A' => Ok(Note::A),
-            'B' => Ok(Note::B),
-            'C' => Ok(Note::C),
-            'D' => Ok(Note::D),
-            'E' => Ok(Note::E),
-            'F' => Ok(Note::F),
-            'G' => Ok(Note::G),
+            'A' => Ok(A),
+            'B' => Ok(B),
+            'C' => Ok(C),
+            'D' => Ok(D),
+            'E' => Ok(E),
+            'F' => Ok(F),
+            'G' => Ok(G),
             _ => Err(anyhow!("unable to create Note from '{}'", c)),
         }
     }

--- a/src/music/scales.rs
+++ b/src/music/scales.rs
@@ -1,5 +1,8 @@
 use crate::music::notes::{Tone, Octave};
 
+//
+// TODO: implement
+//
 
 pub fn c_major(octave: Octave) -> Vec<Tone> {
     let notes = vec!["C", "D", "E", "F", "G", "A", "B"];

--- a/src/music/scales.rs
+++ b/src/music/scales.rs
@@ -1,0 +1,10 @@
+use crate::music::notes::{Tone, Octave};
+
+
+pub fn c_major(octave: Octave) -> Vec<Tone> {
+    let notes = vec!["C", "D", "E", "F", "G", "A", "B"];
+    notes
+        .iter()
+        .map(|n| Tone::try_from(format!("{}{}", n, octave as i32)).unwrap())
+        .collect()
+}

--- a/src/sampling.rs
+++ b/src/sampling.rs
@@ -86,3 +86,14 @@ impl SampleTrack for VecTrack {
         ret
     }
 }
+
+
+/// For compatibility's sake.
+impl SampleTrack for Generator {
+    fn next(&mut self) -> Option<Sample> {
+        Some(self())
+    }
+    fn reset(&mut self) {
+        // no resetting a Generator
+    }
+}


### PR DESCRIPTION
This PR kicks off a framework for defining Western 12-tone (chromatic) music at `psynth::music`. Tools are built out to create and operate on `psynth::music::Tone`s ergonomically.

Also included is a first-pass at some form of real-world actuation via the `SimpleKey` struct at `psynth::keys` (not crazy about the name given the clash with musical key).